### PR TITLE
different methods for getting the q_factors and p_factors of the items and users

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ model.p_factors();
 model.q_factors();
 ```
 
+Get a list of latent factors where each row_index's latent factors are at the vector's index
+```rust
+model.items_p_factors();
+```
+
+Get a list of latent factors where each column_index's latent factors are at the vector's index
+```rust
+model.items_q_factors();
+```
+
 Get the bias (average of all elements in the training matrix)
 
 ```rust

--- a/src/model.rs
+++ b/src/model.rs
@@ -61,6 +61,22 @@ impl Model {
         unsafe { std::slice::from_raw_parts((*self.model).q, (self.columns() * self.factors()) as usize) }
     }
 
+    pub fn items_p_factors(&self) -> Vec<&[f32]> {
+        let mut p_factors_vec = Vec::new();
+        for x in self.p_factors().chunks( self.factors() as usize) {
+            p_factors_vec.push(x);
+        }
+        return p_factors_vec;
+    }
+
+    pub fn items_q_factors(&self) -> Vec<&[f32]> {
+        let mut q_factors_vec = Vec::new();
+        for x in self.q_factors().chunks( self.factors() as usize) {
+            q_factors_vec.push(x);
+        }
+        return q_factors_vec;
+    }
+
     pub fn rmse(&self, data: &Matrix) -> f64 {
         let prob = data.to_problem();
         unsafe { calc_rmse(&prob, self.model) }


### PR DESCRIPTION
For my uses, I have to turn the 1 dimensional list from q_factors and p_factors into the user's and item's factors. This is probably a common use, these functions seem useful for that.